### PR TITLE
Remove cache: yarn to see if that lets corepack work

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,6 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version-file: package.json
-        cache: yarn
 
     - run: yarn install --frozen-lockfile
       shell: bash


### PR DESCRIPTION
Corepack not working is breaking CI when we try to upgrade yarn.

See https://github.com/actions/setup-node/issues/480