### PR TITLE
Update path for rails [MSC-133]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# IDEs
+.idea
+.vscode

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,7 @@ runs:
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
+      working-directory: ./rails/
 
     - run: corepack enable
       shell: bash


### PR DESCRIPTION
This should update the location where the setup-ruby script looks for the .ruby-version and Gemfile.lock files.

Note that this shouldn't "take effect" immediately, we'll have to tag it and update the build files in the webapp repo.

[MSC-133: Update setup-dependencies for new rails path](https://linear.app/euclid-power/issue/MSC-133/update-setup-dependencies-for-new-rails-path)