### PR TITLE
Indent working-directory to pass it to the ruby action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ runs:
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
-      working-directory: ./rails/
+        working-directory: ./rails/
 
     - run: corepack enable
       shell: bash


### PR DESCRIPTION
I'm getting this error: 

```
Error: euclidpower/setup-dependencies-action/v12/action.yml (Line: 18, Col: 7): Unexpected value 'working-directory'
Error: GitHub.DistributedTask.ObjectTemplating.TemplateValidationException: The template is not valid. euclidpower/setup-dependencies-action/v12/action.yml (Line: 18, Col: 7): Unexpected value 'working-directory'
   at GitHub.DistributedTask.ObjectTemplating.TemplateValidationErrors.Check()
   at GitHub.Runner.Worker.ActionManifestManager.ConvertRuns(IExecutionContext executionContext, TemplateContext templateContext, TemplateToken inputsToken, String fileRelativePath, MappingToken outputs)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
Error: Failed to load euclidpower/setup-dependencies-action/v12/action.yml
```

but I think it's just because I need to have it indented.
