### PR TITLE
Add additional step to copy .ruby-version to rails dir

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,11 @@ inputs:
 runs:
   using: composite
   steps:
+    # The ruby/setup-ruby action excepts this file to be located in the working directory
+    # so to avoid having it duplicated in the repo, we copy it during build time
+    - run: cp ${{ github.workspace }}/.ruby-version ./rails/
+      shell: bash
+
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true


### PR DESCRIPTION
The ruby/ruby-setup action expects the .ruby-version file to be inside the working-directory. In order to keep that default action happy and also keep our repo clean, we copy it during build instead of duplicating it in the repo