### PR TITLE
Update Playwright to 1.52.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   playwright_version:
     description: The version we are using
     required: false
-    default: "1.49.0"
+    default: "1.52.0"
 runs:
   using: composite
   steps:


### PR DESCRIPTION
The version of Playwright we are currently caching on CI is older than the version we are requiring in [package.json](https://github.com/euclidpower/webapp/blob/main/package.json#L20). It looks like this was missed the last time Playwright was updated.