### PR TITLE
Update Playwright version to 1.54.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   playwright_version:
     description: The version we are using
     required: false
-    default: "1.53.0"
+    default: "1.54.1"
 runs:
   using: composite
   steps:


### PR DESCRIPTION
This [Dependabot PR](https://github.com/euclidpower/webapp/actions/runs/16354029353) where Playwright got auto-updated somehow passed build and successfully auto-merged despite the Playwright version **not** matching what's defined in `setup-dependencies-action` (1.53.0 vs 1.54.1). This was failing (as expected) prior to migrating to Blacksmith.

That should be investigated (is it caching too aggressively?). But for now, let's get the correct Playwright version declared so we don't break CI.