### PR TITLE
Read Playwright version from package.json instead of declaring manually

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,6 @@ inputs:
     description: Should Cache Playwright binaries
     required: false
     default: "0"
-  playwright_version:
-    description: The version we are using
-    required: false
-    default: "1.54.1"
 runs:
   using: composite
   steps:
@@ -30,18 +26,32 @@ runs:
         node-version-file: package.json
         cache: 'yarn'
 
+    - name: 'Get Playwright version from package.json'
+      if: inputs.cache_playwright != '0'
+      id: get-playwright-version
+      shell: bash
+      run: |
+        PLAYWRIGHT_VERSION=`jq '.dependencies["@playwright/test"]' package.json`
+        if [[ "$PLAYWRIGHT_VERSION" == "null" ]] || [[ -z "$PLAYWRIGHT_VERSION" ]]; then
+          echo "Failed to locate Playwright version"
+          exit 1
+        fi
+
+        echo "Current Playwright version: $PLAYWRIGHT_VERSION"
+        echo playwright-version='$PLAYWRIGHT_VERSION' >> "$GITHUB_OUTPUT"
+
     - run: yarn install --immutable
       shell: bash
 
     - name: Cache Playwright binaries
-      if: inputs.cache_playwright != '0'
+      if: inputs.cache_playwright != '0' && steps.get-playwright-version.outputs.playwright-version != ''
       uses: actions/cache@v4
       id: playwright-cache
       with:
         path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ inputs.playwright_version }}
+        key: ${{ runner.os }}-playwright-${{ $PLAYWRIGHT_VERSION }}
 
     - name: Download Playwright dependencies and browsers
-      if: inputs.cache_playwright != '0' && steps.playwright-cache.outputs.cache-hit != 'true'
+      if: steps.get-playwright-version.outputs.playwright-version != '' && steps.playwright-cache.outputs.cache-hit != 'true'
       run: yarn playwright install --with-deps chromium
       shell: bash


### PR DESCRIPTION
I tried to use an existing GH action for this, but it didn't work and was annoying to debug.

I tested this approach directly in our build.yml to validate it before adding it here.

This automatically determines which Playwright version to use by checking package.json.

I removed the option to pass in a Playwright version or set a default in action.yml to simplify the logic. If we tell the action to cache Playwright, it tries to find the Playwright version from package.json, and exits early if it is not found. It  logs which version it found for clarity.

Having the version set in only one place will make it easier to figure out what's going on when CI isn't acting right.